### PR TITLE
Fix response headers for documentation pages

### DIFF
--- a/ansible/templates/vhosts.conf
+++ b/ansible/templates/vhosts.conf
@@ -62,4 +62,16 @@ SSLProxyProtocol all -SSLv3
   # Note that this is NOT a redirect; it allows the v2 URLs to continue to work transparently from the user's POV.
   # See https://httpd.apache.org/docs/2.4/rewrite/remapping.html#old-to-new
   RewriteRule "^/content/repositories/(.+)" "/repository/$1" [PT]
+
+  # turn off for Content-Security related headers for documentation pages to properly work
+  # Nexus turns these headers on 
+  # (https://groups.google.com/a/glists.sonatype.com/forum/#!topic/nexus-users/D7UPFrF9RWM)
+  # and while we can turn these off in the Nexus config, it would be off globally for all 
+  # of the server. Rather than doing it globally, we are turning them off just for URL paths
+  # that involve our documentation.
+  <Location "/repository/thredds-doc/">
+    Header unset Content-Security-Policy
+    Header unset X-Content-Security-Policy
+  </Location> 
+
 </VirtualHost>


### PR DESCRIPTION
Nexus turns on some headers for sandboxing (https://groups.google.com/a/glists.sonatype.com/forum/#!topic/nexus-users/D7UPFrF9RWM) and these headers cause our documentation pages to malfunction (specifically the javascript stuff). While we can turn these off in the Nexus config, it would be off globally for all of the server. Rather than doing it globally, this turns them off for just URL paths that involve our documentation.